### PR TITLE
chore: Claude Code harness 설정 추가

### DIFF
--- a/.claude/hooks/format-file.sh
+++ b/.claude/hooks/format-file.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# PostToolUse(Edit|Write) hook: format the edited file with Biome.
+# Receives the hook event JSON on stdin; exits 0 always (non-blocking).
+set -u
+
+f=$(jq -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -z "$f" ] && exit 0
+[ -f "$f" ] || exit 0
+
+case "$f" in
+  *.ts | *.tsx | *.js | *.jsx | *.mjs | *.json | *.css) ;;
+  *) exit 0 ;;
+esac
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+pnpm exec biome check --write "$f" >/dev/null 2>&1 || true
+exit 0

--- a/.claude/rules/docs-localization.md
+++ b/.claude/rules/docs-localization.md
@@ -1,0 +1,18 @@
+---
+paths:
+  - "docs/**"
+---
+
+# Documentation & Localization Rules
+
+Source: docs/en/policy/policy.md (Documentation Structure)
+
+- `docs/en/` is the source of truth. Write or update English first.
+- Every change under `docs/en/` requires a mirrored Korean translation at the identical path under `docs/ko/` (same filename, no `.ko` suffix). Use the `sync-translations` skill for bulk syncs.
+- Code blocks, file paths, commands, and identifiers stay in English inside Korean docs.
+- `docs/reference/` holds external API/SDK references — English only, never translated (see docs/en/policy/reference-convention.md).
+- Every policy/spec document starts with the header comment:
+  `<!-- Created: YYYY-MM-DD | Last Modified: YYYY-MM-DD | Status: Active -->`
+  Update `Last Modified` when editing.
+- One document per topic — no duplication across files; link instead.
+- Domain specs live in `docs/en/specifications/<domain>/` with the 6-document pipeline: requirements → user-stories → use-cases → sequence-diagram → component/api-spec → test-spec (use the `dev-planning` skill for new domains).

--- a/.claude/rules/fsd-architecture.md
+++ b/.claude/rules/fsd-architecture.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "src/**"
+---
+
+# FSD Architecture & Code Naming Rules
+
+Source: docs/en/specifications/architecture.md, docs/en/policy/naming-conventions.md
+
+## Import Direction (strict)
+
+Layers may only import from the same level or lower:
+
+```text
+app/ → widgets/ → features/ → entities/ → shared/
+```
+
+- NEVER import upward (e.g., `entities/` must not import from `features/`).
+- Cross-imports between slices on the same layer are also discouraged — go through a lower layer instead.
+
+## Feature Internal Structure
+
+```text
+src/features/<name>/
+├── ui/          # UI components
+├── api/         # API calls and business logic
+├── hooks/       # Custom React hooks
+└── index.ts     # Public exports (import features only via this barrel)
+```
+
+## Naming
+
+| Target | Convention | Example |
+|--------|-----------|---------|
+| Files / directories | `kebab-case` | `post-card.tsx` |
+| React components | `PascalCase` export from kebab-case file | `export const PostCard` |
+| Functions / variables | `camelCase` | `fetchPosts()` |
+| Constants | `UPPER_SNAKE_CASE` | `ISR_REVALIDATE_TIME` |
+| Types / interfaces | `PascalCase` (domain interfaces use `I` prefix: `IPost`) | `type TagName = string` |
+| Private methods | `_camelCase` | `private _validatePost()` |
+| Test files | `<name>.test.ts(x)` | `post.test.ts` |
+
+- Domain models (Post, Tag, Guestbook) use private constructors with static `create()` factories.
+- shadcn/ui components live in `src/shared/ui/` — import as `@/shared/ui/<component>`.
+- Anything about AI summaries is named `summary`, never `ai`-prefixed (`summary-card.tsx`, `getSummary()`, `SummaryButton`).
+
+## TypeScript
+
+- Strict mode; no `any` — prefer `unknown` with type narrowing.
+- Use type guards for domain model validation.

--- a/.claude/rules/notion-data-patterns.md
+++ b/.claude/rules/notion-data-patterns.md
@@ -1,0 +1,48 @@
+---
+paths:
+  - "src/shared/api/**"
+  - "src/shared/lib/**"
+  - "src/entities/**"
+  - "src/features/**"
+  - "src/app/api/**"
+---
+
+# Notion, Caching & LLM Data Patterns
+
+Source: docs/en/specifications/config.md, docs/en/specifications/infrastructure.md
+
+## Dual Notion Clients (do not mix them up)
+
+| Client | Export | Use for | Env vars |
+|--------|--------|---------|----------|
+| `@notionhq/client` (official) | `notion` in `src/shared/api/notion.ts` | Database queries, property updates | `NOTION_KEY` |
+| `notion-client` + `react-notion-x` (unofficial) | `notionApi` in `src/shared/api/notion.ts` | Rendering rich page content | `NOTION_TOKEN_V2`, `NOTION_USER_ID` |
+
+## Notion Database Properties are Korean
+
+Use the exact Korean property names: `제목` (Title), `날짜` (Date), `상태` (Status), `Tags`.
+
+## Server-Side Caching
+
+- All Notion fetches go through `nextServerCache()` from `src/shared/lib/cache.ts`.
+- Revalidation: 30s (dev) / 300s (prod), configured in `src/shared/config/index.ts`.
+- After ANY Notion mutation, invalidate the cache:
+
+```typescript
+import { revalidateTag, revalidatePath } from "next/cache";
+
+revalidateTag("posts");
+revalidatePath("/posts");
+revalidatePath(`/posts/${postId}`);
+```
+
+Canonical example: `src/app/api/posts/[postId]/summary/route.ts`.
+
+## Environment-Based LLM Selection
+
+`src/shared/api/openai.ts` picks the provider by environment:
+
+- Production: OpenAI API (`OPENAI_API_KEY`, model `gpt-4o-mini`)
+- Development: Ollama via `LOCAL_AI_ENDPOINT` (model `gemma3:1b`), using the OpenAI SDK (Ollama is OpenAI-compatible)
+
+Never hardcode a provider; keep both paths working.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "vitest.config.*"
+  - "src/mocks/**"
+---
+
+# Testing Rules
+
+Source: docs/en/policy/policy.md (Testing section), docs/en/specifications/*/test-spec
+
+## Coverage Targets
+
+| Code type | Target |
+|-----------|--------|
+| Entities / domain models | 80%+ |
+| API routes | 80%+ |
+| Features with user interaction | 70%+ |
+| UI components with logic | 50%+ |
+
+Do NOT test: simple presentational components, type definitions, config files, third-party wrappers without custom logic.
+
+## Commands
+
+- `pnpm test --run` — Vitest with MSW mocking (default; plain `pnpm test` starts watch mode).
+- `pnpm test:deep` — hits the real Notion API; requires credentials and costs quota. Never run it casually — ask the user first.
+
+## Conventions
+
+- Test files: `<name>.test.ts` / `<name>.test.tsx`, colocated with the code under test.
+- Mock external APIs (Notion, OpenAI, email) with MSW — tests must pass offline.
+- Each domain has a test-spec in `docs/en/specifications/<domain>/`; keep test IDs traceable to it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,8 +19,8 @@
       "Bash(pnpm test:deep)"
     ],
     "deny": [
-      "Read(./.env)",
-      "Read(./.env.*)"
+      "Read(/.env)",
+      "Read(/.env.*)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,55 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint)",
+      "Bash(pnpm build)",
+      "Bash(pnpm biome:write)",
+      "Bash(pnpm test --run)",
+      "Bash(pnpm test --run *)",
+      "Bash(pnpm exec biome *)",
+      "Bash(gh issue list *)",
+      "Bash(gh issue view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh run list *)",
+      "Bash(gh run view *)"
+    ],
+    "ask": [
+      "Bash(pnpm test:deep)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/format-file.sh\"",
+            "timeout": 60,
+            "statusMessage": "Biome formatting edited file..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "prompt",
+            "if": "Bash(git commit *)",
+            "prompt": "You are validating a git commit command against this repo's commit message rule (docs/en/policy/commit-message-rule.md). The command is in $ARGUMENTS. If the command is NOT a git commit with a message (no -m argument, an editor-based commit, or an amend without a new message), answer ok=true immediately. Otherwise extract the commit message (the -m argument, including heredoc form). The first line must match: '<type>: <Korean summary>' where type is one of feat, fix, style, chore, lint, config, perf, seo, docs, test; the summary is written in Korean; the line does not end with a period; and the full first line is under 72 characters. An optional issue reference like '(refs #93)' at the end is allowed. Answer ok=true if the message complies, ok=false with the specific violation if not.",
+            "timeout": 30,
+            "statusMessage": "Validating commit message format..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,4 @@
 {
+  "root": true,
   "extends": "next/core-web-vitals"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ google*.html
 # logs
 *.log
 
-# agents
-.claude
+# agents — ignore local/session state, but commit shared team config
+.claude/*
+!.claude/settings.json
+!.claude/rules
+!.claude/hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,16 +1,14 @@
 # Claude Code Instructions
 
-This file provides optimized guidance for AI agents (Claude Code, GitHub Copilot, etc.) working with code in this repository.
+This file provides guidance for AI agents (Claude Code, GitHub Copilot, etc.) working with code in this repository.
 
 ## Your Role
 
 You are a **Product Owner (PO) with comprehensive web service expertise**. However, you cannot remember everything, so you must:
 
-- **Always consult `docs/` directory** before making decisions or taking actions
+- **Always consult `docs/`** before making decisions or taking actions
 - **Reference documented patterns and decisions** rather than relying on assumptions
-- **Plan work based on documented requirements and specifications**
 - **Update documentation** as you learn and make changes
-- **Follow established conventions** documented in policy files
 
 **Core Principle**: Documentation is your external memory. Read first, then act.
 
@@ -18,364 +16,106 @@ You are a **Product Owner (PO) with comprehensive web service expertise**. Howev
 
 **Project Type**: Personal technical blog built with Next.js 14 (App Router) and TypeScript, using Notion as headless CMS
 
-**Architecture**: Feature-Sliced Design (FSD) with strict layer boundaries — see [docs/en/specifications/architecture.md](docs/en/specifications/architecture.md)
-
-**Tech Stack**: Next.js 14, TypeScript (strict mode), Tailwind CSS, shadcn/ui, Notion API, OpenAI API, pnpm
-
-**Documentation Structure**:
-- `docs/en/` — English (source of truth)
-- `docs/ko/` — Korean translations (mirror of `docs/en/`)
-- `docs/reference/` — External API/SDK references (no translation)
-
-**Key Constraint**: Always read and update [docs/](docs/) when working on this project. All decisions must be documented.
-
-## Task Routing (What to Read When)
-
-Use this decision tree to find relevant documentation. **Always read the linked documents** before taking action.
-
-### Development Workflow Tasks
-
-| Task | Primary Document |
-|------|-----------------|
-| **Making a commit** | [docs/en/policy/commit-message-rule.md](docs/en/policy/commit-message-rule.md) |
-| **Naming files/code** | [docs/en/policy/naming-conventions.md](docs/en/policy/naming-conventions.md) |
-| **Creating a branch / PR / issue** | [docs/en/policy/policy.md](docs/en/policy/policy.md) |
-| **Adding a reference doc** | [docs/en/policy/reference-convention.md](docs/en/policy/reference-convention.md) |
-| **Understanding workflow** | [docs/en/policy/policy.md](docs/en/policy/policy.md) |
-
-### Feature Development Tasks
-
-| Task | Primary Document |
-|------|-----------------|
-| **Implementing a post feature** | [docs/en/specifications/post/](docs/en/specifications/post/) |
-| **Implementing a guestbook feature** | [docs/en/specifications/guestbook/](docs/en/specifications/guestbook/) |
-| **Implementing summary (AI) features** | [docs/en/specifications/summary/](docs/en/specifications/summary/) |
-| **Implementing site/theme/profile features** | [docs/en/specifications/site/](docs/en/specifications/site/) |
-| **Understanding architecture** | [docs/en/specifications/architecture.md](docs/en/specifications/architecture.md) |
-| **Setting up environment / config** | [docs/en/specifications/config.md](docs/en/specifications/config.md) |
-| **Setting up infrastructure** | [docs/en/specifications/infrastructure.md](docs/en/specifications/infrastructure.md) |
-
-### Documentation Tasks
-
-| Task | Primary Document |
-|------|-----------------|
-| **Domain index** | [docs/en/specifications/README.md](docs/en/specifications/README.md) |
-| **Korean translation** | Mirror in `docs/ko/` (same path, same filename) |
-| **Adding API reference** | Add to [docs/reference/](docs/reference/) — English only |
-
-## Quick Reference (Essential Rules)
-
-### Architecture Quick Reference
-
-**FSD Layer Hierarchy** (Feature-Sliced Design):
+**Architecture**: Feature-Sliced Design (FSD) with strict layer boundaries:
 
 ```text
 app/     →  widgets/  →  features/  →  entities/  →  shared/
 (Routes)    (Layouts)    (Features)     (Models)      (Utils)
 ```
 
-**Import Rules**:
+Import same level or lower only — never upward. Details load automatically from `.claude/rules/fsd-architecture.md` when you touch `src/`.
 
-- ✅ Each layer can import from the **same level or lower**
-- ❌ **NEVER import upward** (e.g., `entities/` cannot import from `features/`)
+**Tech Stack**: Next.js 14, TypeScript (strict mode), Tailwind CSS, shadcn/ui (in `src/shared/ui/`), Notion API, OpenAI API, pnpm
 
-**Layer Responsibilities**:
+**Documentation Structure**:
+- `docs/en/` — English (source of truth)
+- `docs/ko/` — Korean translations (mirror of `docs/en/`)
+- `docs/reference/` — External API/SDK references (no translation)
 
-```text
-src/
-├── app/           # Next.js App Router — routes, layouts, API endpoints
-├── widgets/       # Composite UI — Header (cross-feature layouts)
-├── features/      # User features — post, tag, guestbook, summary, profile, theme
-├── entities/      # Domain models — Post, Tag, Guestbook, Alarm
-└── shared/        # Cross-cutting — cache, logger, UI primitives, config, API clients
-```
+## Claude Code Harness
 
-### File Naming
+This repo ships committed Claude Code configuration — rely on it instead of re-stating rules:
 
-| Type | Convention | Example |
-|------|-----------|---------|
-| Files / directories | `kebab-case` | `post-card.tsx`, `summary/` |
-| React components | `PascalCase` (exported from kebab-case files) | `export const PostCard = () => {}` |
-| Functions / variables | `camelCase` | `fetchPosts()`, `postData` |
-| Constants | `UPPER_SNAKE_CASE` | `ISR_REVALIDATE_TIME` |
-| Types / Interfaces | `PascalCase` | `interface PostData {}` |
-| Private methods | `_camelCase` (prefix underscore) | `private _validatePost()` |
+**`.claude/rules/`** — path-scoped rules that load automatically when you work on matching files:
 
-**Reference**: [docs/en/policy/naming-conventions.md](docs/en/policy/naming-conventions.md)
+| Rule file | Loads for | Covers |
+|-----------|-----------|--------|
+| `fsd-architecture.md` | `src/**` | FSD import direction, layer map, naming conventions, `summary` (never `ai`) naming |
+| `notion-data-patterns.md` | `src/shared/**`, `src/entities/**`, `src/features/**`, `src/app/api/**` | Dual Notion clients, Korean DB property names, `nextServerCache()` + cache invalidation, env-based LLM selection |
+| `docs-localization.md` | `docs/**` | en→ko mirroring, header comments, reference conventions |
+| `testing.md` | `**/*.test.ts(x)`, `vitest.config.*`, `src/mocks/**` | Coverage targets, MSW mocking, `test:deep` caution |
 
-### Commits
+**`.claude/settings.json`** — permissions and hooks:
 
-**Format**: `<type>: <한글 요약>`
+- Edited files are **auto-formatted by Biome** (PostToolUse hook) — don't run formatting manually after each edit; run `pnpm biome:write` once before committing for the full `--unsafe` pass.
+- `git commit` messages are **validated by a hook** against the commit rule below; non-compliant commits are blocked.
+- `pnpm lint` / `pnpm build` / `pnpm test --run` / `gh` read commands are pre-allowed; `pnpm test:deep` always asks (real Notion API); `.env*` reads are denied.
 
-**Available Types**: `feat`, `fix`, `style`, `chore`, `lint`, `config`, `perf`, `seo`, `docs`, `test`
+Agents that don't read `.claude/` (e.g., GitHub Copilot): the same rules live in `docs/en/policy/` and `docs/en/specifications/` — use the routing table below.
 
-**Rules**:
+## Task Routing (What to Read When)
 
-- Summary in Korean
-- No period
-- Under 72 characters
-- Issue reference: `(refs #93)` or `(refs issue088)`
+| Task | Primary Document |
+|------|-----------------|
+| **Making a commit** | [docs/en/policy/commit-message-rule.md](docs/en/policy/commit-message-rule.md) |
+| **Naming files/code** | [docs/en/policy/naming-conventions.md](docs/en/policy/naming-conventions.md) |
+| **Branch / PR / issue / workflow / testing** | [docs/en/policy/policy.md](docs/en/policy/policy.md) |
+| **Adding a reference doc** | [docs/en/policy/reference-convention.md](docs/en/policy/reference-convention.md) |
+| **Post features** | [docs/en/specifications/post/](docs/en/specifications/post/) |
+| **Guestbook features** | [docs/en/specifications/guestbook/](docs/en/specifications/guestbook/) |
+| **Summary (AI) features** | [docs/en/specifications/summary/](docs/en/specifications/summary/) |
+| **Site/theme/profile features** | [docs/en/specifications/site/](docs/en/specifications/site/) |
+| **Architecture** | [docs/en/specifications/architecture.md](docs/en/specifications/architecture.md) |
+| **Environment / config** | [docs/en/specifications/config.md](docs/en/specifications/config.md) |
+| **Infrastructure** | [docs/en/specifications/infrastructure.md](docs/en/specifications/infrastructure.md) |
+| **Domain index** | [docs/en/specifications/README.md](docs/en/specifications/README.md) |
 
-**Examples**:
+Each domain spec has 6 documents: requirements → user-stories → use-cases → sequence-diagram → component/api-spec → test-spec.
+
+## Commits & Pull Requests
+
+**Commit format**: `<type>: <한글 요약>` — Korean summary, no trailing period, under 72 characters, optional `(refs #93)`.
+
+**Types**: `feat`, `fix`, `style`, `chore`, `lint`, `config`, `perf`, `seo`, `docs`, `test`
 
 ```bash
 feat: AI 요약 생성 기능 추가
-fix: 모바일 헤더 반응형 레이아웃 적용
 docs: post 도메인 명세 작성 (refs #93)
 ```
 
-**Reference**: [docs/en/policy/commit-message-rule.md](docs/en/policy/commit-message-rule.md)
+**Branch naming**: `<type>/<issue-number>[-description]` (e.g., `feat/93-docs-refactor`)
 
-### Pull Requests
+**PR checklist**: reference the issue, update docs (en + ko mirror), and pass `pnpm lint`, `pnpm biome:write`, `pnpm test`.
 
-**Branch Naming**: `<type>/<issue-number>[-description]`
-
-**PR Requirements**:
-
-1. Reference issue in PR description
-2. Update documentation if needed
-3. Run `pnpm lint` and `pnpm test` before creating PR
-
-**Reference**: [docs/en/policy/policy.md](docs/en/policy/policy.md)
-
-### Testing
-
-**Coverage Targets**:
-
-| Code Type | Target |
-|-----------|--------|
-| Entities / domain models | 80%+ |
-| API routes | 80%+ |
-| Features with user interaction | 70%+ |
-| UI components with logic | 50%+ |
-
-**Test Commands**:
+## Commands & Environment
 
 ```bash
-pnpm test       # Standard tests with MSW mocking
-pnpm test:deep  # Real Notion API calls (requires valid credentials)
-```
-
-**Reference**: [docs/en/policy/policy.md](docs/en/policy/policy.md) (Testing section)
-
-## Environment & Infrastructure
-
-### Required Environment Variables
-
-See [docs/en/specifications/config.md](docs/en/specifications/config.md) for the complete list. Key variables:
-
-```bash
-# Notion (Required)
-NOTION_KEY=secret_xxx                        # Internal integration token
-NOTION_TOKEN_V2=xxx                          # Browser cookie token
-NOTION_USER_ID=xxx                           # Notion active user ID
-NOTION_POST_DATABASE_ID=xxx
-NOTION_GUESTBOOK_DATABASE_ID=xxx
-NOTION_ABOUT_PAGE_ID=xxx                     # About page
-
-# AI / LLM
-OPENAI_API_KEY=sk-xxx                        # Production
-LOCAL_AI_ENDPOINT=http://localhost:11434     # Development (Ollama)
-
-# Email
-AUTH_USER=your@gmail.com
-AUTH_PASS=xxxx xxxx xxxx xxxx                # Gmail app password
-
-# SEO
-BLOG_URL=https://...
-NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
-GOOGLE_SITE_VERIFICATION=googleXXX.html
-```
-
-### Common Commands
-
-```bash
-# Development
-pnpm dev              # Start dev server at http://localhost:3000
+pnpm dev              # Dev server at http://localhost:3000
 pnpm build            # Production build with ISR
-pnpm start            # Serve production build
-
-# Code Quality
 pnpm lint             # ESLint (next/core-web-vitals)
-pnpm biome:write      # Format code with Biome
-
-# Testing
-pnpm test             # Vitest with MSW mocking
-pnpm test:deep        # Real API integration tests
+pnpm biome:write      # Biome format + safe/unsafe fixes
+pnpm test --run       # Vitest with MSW mocking (plain `pnpm test` = watch mode)
+pnpm test:deep        # Real Notion API calls — requires credentials, ask first
 ```
 
-## Critical Patterns
-
-### Dual Notion Client Setup
-
-This project uses **two separate** Notion client libraries:
-
-**1. Official Client** (`@notionhq/client`):
-- **Location**: `src/shared/api/notion.ts` (`notion`)
-- **Use for**: Querying databases, updating properties
-- **Requires**: `NOTION_KEY`
-
-**2. Unofficial Client** (`notion-client` + `react-notion-x`):
-- **Location**: `src/shared/api/notion.ts` (`notionApi`)
-- **Use for**: Rendering rich page content
-- **Requires**: `NOTION_TOKEN_V2`, `NOTION_USER_ID`
-
-**Notion Database Properties** use **Korean names**:
-
-- 제목 (Title), 날짜 (Date), 상태 (Status), Tags
-
-### Domain Models (Protected Constructor Pattern)
-
-All domain entities use private constructors with static `create()` factories. See:
-- `src/entities/post/model/index.ts` (Post, Tag)
-- `src/entities/guestbook/model/index.ts` (Guestbook)
-
-### Server-Side Caching Strategy
-
-All Notion data fetching uses `nextServerCache()` from `src/shared/lib/cache.ts`.
-
-**Cache config** (`src/shared/config/index.ts`):
-- Development: 30s revalidation
-- Production: 300s (5 min) revalidation
-
-**Cache Invalidation Pattern** (after Notion updates):
-
-```typescript
-import { revalidateTag, revalidatePath } from 'next/cache';
-
-revalidateTag('posts');
-revalidatePath('/posts');
-revalidatePath(`/posts/${postId}`);
-```
-
-See: `src/app/api/posts/[postId]/summary/route.ts` for the canonical example.
-
-### Environment-Based LLM Selection
-
-AI summary generation uses different LLM providers based on environment (`src/shared/api/openai.ts`):
-
-- **Production**: OpenAI API (`OPENAI_API_KEY`, model `gpt-4o-mini`)
-- **Development**: Local LLM endpoint (`LOCAL_AI_ENDPOINT`, model `gemma3:1b` by default)
-
-Both use the OpenAI SDK because Ollama is OpenAI-compatible.
-
-### Summary Naming
-
-Always use `summary` for AI-generated summaries — never prefix with `ai`. Examples:
-
-| Correct | Incorrect |
-|---------|-----------|
-| `summary-card.tsx` | `ai-summary-card.tsx` |
-| `getSummary()` | `getAiSummary()` |
+Environment variables: see [docs/en/specifications/config.md](docs/en/specifications/config.md). Groups: Notion (`NOTION_KEY`, `NOTION_TOKEN_V2`, `NOTION_USER_ID`, database/page IDs), LLM (`OPENAI_API_KEY` prod / `LOCAL_AI_ENDPOINT` dev), Email (`AUTH_USER`, `AUTH_PASS` — Gmail **app password**, not the regular one), SEO (`BLOG_URL`, `NEXT_PUBLIC_GA_ID`, `GOOGLE_SITE_VERIFICATION`).
 
 ## Documentation-Driven Workflow
 
-### Before Starting Work
+1. **Before starting**: check [GitHub Issues](https://github.com/ywj3493/metis-blog/issues); create one if missing (`gh issue create`, see `/new-issue` skill); read the relevant domain spec.
+2. **While working**: update docs when architecture or requirements change; add tests per the domain test-spec; reference the issue in commits.
+3. **Before PR**: update `docs/en/` and mirror to `docs/ko/` (see `/sync-translations` skill); verify tests pass.
 
-1. **Check for existing issue** on [GitHub Issues](https://github.com/ywj3493/metis-blog/issues)
-2. **Create issue** if missing — use `gh issue create` (see `/new-issue` skill)
-3. **Read relevant specs** in `docs/en/specifications/<domain>/`
+## Gotchas Not Covered by Rules
 
-### While Working
-
-1. **Update documentation** if architecture or requirements change
-2. **Add tests** following [test specs](docs/en/specifications/) (one per domain)
-3. **Run quality checks**: `pnpm lint` and `pnpm biome:write` before commits
-4. **Reference issue** in commits: `(refs #<number>)`
-
-### Before Creating PR
-
-1. **Update relevant docs** in `docs/en/` (and mirror in `docs/ko/`)
-2. **Reference issue** in PR description
-3. **Verify tests pass**: `pnpm test`
-
-**Reference**: [docs/en/policy/policy.md](docs/en/policy/policy.md)
-
-## Important Gotchas
-
-### Notion Property Names
-
-- Database properties are in **Korean**: 제목, 날짜, 상태, Tags
-
-### shadcn/ui Component Location
-
-- Components installed to `src/shared/ui/` (not default `@/components`)
-- Import: `import { Button } from '@/shared/ui/button'`
-
-### Cache Invalidation is Critical
-
-- **Always** call `revalidateTag()` and `revalidatePath()` after Notion updates
-- See [cache strategy](#server-side-caching-strategy) above
-
-### Gmail Authentication
-
-- `AUTH_PASS` requires **app password** (not regular Gmail password)
-- Generate at: Google Account → Security → 2-Step Verification → App passwords
-
-### Image Optimization
-
-Remote patterns configured in `next.config.mjs`:
-- `www.notion.so`
-- `noticon-static.tammolo.com`
-
-## Deep Dive Documentation
-
-### Specifications
-
-- **[Architecture](docs/en/specifications/architecture.md)** — FSD layers, design patterns, module inventory
-- **[Config](docs/en/specifications/config.md)** — Environment variables, app config, Notion property names
-- **[Infrastructure](docs/en/specifications/infrastructure.md)** — Tech stack, deployment, caching, external services
-- **[Domain Index](docs/en/specifications/README.md)** — All four domains (post, guestbook, summary, site)
-
-### Domain Specifications
-
-Each domain has 6 documents (requirements → user-stories → use-cases → sequence-diagram → component/api-spec → test-spec):
-
-- **[post](docs/en/specifications/post/)** — Post listing, detail, filtering, tags, navigation
-- **[guestbook](docs/en/specifications/guestbook/)** — Guestbook CRUD with email notifications
-- **[summary](docs/en/specifications/summary/)** — AI-generated post summaries
-- **[site](docs/en/specifications/site/)** — Theme, navigation, profile, About, SEO
-
-### Policies
-
-- **[Policy](docs/en/policy/policy.md)** — Development workflow, code quality, testing
-- **[Commit Message Rule](docs/en/policy/commit-message-rule.md)** — Format and types
-- **[Naming Conventions](docs/en/policy/naming-conventions.md)** — Files, code, components
-- **[Reference Convention](docs/en/policy/reference-convention.md)** — Adding external docs
-
-## Localization
-
-All documentation under `docs/en/` (English) is mirrored under `docs/ko/` (Korean) using the same file structure and filenames (no `.ko` suffix).
-
-**Workflow**:
-
-1. Write English documentation in `docs/en/<path>/<file>.md`
-2. Mirror Korean translation in `docs/ko/<path>/<file>.md`
-3. Keep file paths and structure parallel
-4. Code blocks, file paths, and commands stay in English in Korean docs
-
-**Example**:
-
-- English: `docs/en/specifications/post/requirements/requirements.md`
-- Korean: `docs/ko/specifications/post/requirements/requirements.md`
+- **Image optimization**: remote patterns in `next.config.mjs` — `www.notion.so`, `noticon-static.tammolo.com`. Add new image hosts there.
+- **Gmail**: `AUTH_PASS` must be an app password (Google Account → Security → 2-Step Verification → App passwords).
 
 ## Agent Responsibilities
 
-### AI Agent's Role
+**AI agent**: read docs first; keep docs current; create issues for new work; follow all policies; ask when unclear rather than assume.
 
-1. **Read docs first**: Always consult [docs/](docs/) before implementing changes
-2. **Update docs**: Keep documentation current with code changes
-3. **Create issues**: Use `gh issue create` for new work (see `/new-issue` skill)
-4. **Follow conventions**: Adhere to all policies (commits, naming, testing)
-5. **Ask when unclear**: Request clarification rather than assume
-
-### Human Developer's Role
-
-1. **Review work**: Verify implementations align with intent
-2. **Provide context**: Share domain knowledge and business requirements
-3. **Add references**: Add external API docs to [docs/reference/](docs/reference/)
-4. **Make decisions**: Resolve ambiguities and approve architectural approaches
-5. **Maintain translations**: Update Korean docs in [docs/ko/](docs/ko/)
+**Human developer**: review implementations; provide domain/business context; add external API docs to `docs/reference/`; make architectural decisions; approve PRs.
 
 ## Navigation Hub
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ This repo ships committed Claude Code configuration — rely on it instead of re
 - `git commit` messages are **validated by a hook** against the commit rule below; non-compliant commits are blocked.
 - `pnpm lint` / `pnpm build` / `pnpm test --run` / `gh` read commands are pre-allowed; `pnpm test:deep` always asks (real Notion API); `.env*` reads are denied.
 
+Path-scoped rules load when a matching file is **read** — when creating a brand-new file without reading neighbors first, remember at minimum:
+
+- All files and directories use `kebab-case`.
+- Every `docs/en/` change needs a `docs/ko/` mirror at the identical path.
+- Policy/spec docs start with `<!-- Created: YYYY-MM-DD | Last Modified: YYYY-MM-DD | Status: Active -->`.
+
 Agents that don't read `.claude/` (e.g., GitHub Copilot): the same rules live in `docs/en/policy/` and `docs/en/specifications/` — use the routing table below.
 
 ## Task Routing (What to Read When)


### PR DESCRIPTION
Resolves #97

## Summary

CLAUDE.md와 `docs/` 정책 문서의 규칙을 Claude Code 네이티브 기능(project settings, hooks, path-scoped rules)으로 옮겨, 에이전트 작업 시 규칙이 자동으로 로드·강제되도록 합니다.

## Changes

### `.claude/settings.json` (팀 공유 설정)
- **권한**: `pnpm lint`/`build`/`biome:write`/`test --run`, `gh` 읽기 명령 사전 허용 / `pnpm test:deep`(실제 Notion API)은 항상 확인 / `.env*` 읽기 차단
- **PostToolUse 훅**: Edit/Write 시 해당 파일을 Biome으로 자동 포맷 (`.claude/hooks/format-file.sh`)
- **PreToolUse 프롬프트 훅**: `git commit` 메시지를 commit-message-rule에 따라 검증, 위반 시 차단

### `.claude/rules/` (경로 조건부 규칙 — 해당 경로 작업 시에만 컨텍스트 로드)
| 파일 | 발동 경로 | 내용 |
|------|----------|------|
| `fsd-architecture.md` | `src/**` | FSD import 방향, 네이밍, summary(≠ai) 규칙 |
| `notion-data-patterns.md` | `src/shared/**` 외 | 이중 Notion 클라이언트, 한글 프로퍼티, 캐시 무효화, LLM 선택 |
| `docs-localization.md` | `docs/**` | en→ko 미러 규칙, 헤더 코멘트 |
| `testing.md` | `**/*.test.ts(x)` 외 | 커버리지 목표, MSW, test:deep 주의 |

### 기타
- `.gitignore`: `.claude` 전체 무시 → 공유 설정(`settings.json`, `rules/`, `hooks/`)만 추적하도록 조정 (개인 `settings.local.json`, worktree는 계속 무시)
- `CLAUDE.md`: rules로 위임된 세부 내용을 축약(383→135줄)하고 harness 안내 섹션 추가 — 항상 로드되는 컨텍스트 비용 절감
- `.eslintrc.json`: `root: true` 추가 — 워크트리에서 상위 체크아웃 설정과의 이중 로드 충돌 해결

## Verification

- [x] Biome 포맷 훅: 파이프 테스트 + 라이브 검증(포맷 어긋난 파일이 편집 직후 자동 수정됨)
- [x] 커밋 메시지 훅: 본 PR의 커밋들이 훅 검증을 통과하며 생성됨
- [x] `git add --dry-run`으로 gitignore 추적 범위 확인
- [x] `pnpm lint` 통과
- [x] `pnpm test --run` 통과 (2건은 DEEP_TEST 전용 스킵)

🤖 Generated with [Claude Code](https://claude.com/claude-code)