### PR TITLE
config: explainable 플러그인 프로젝트 스코프로 설치

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,5 +51,16 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "claude-skills": {
+      "source": {
+        "source": "github",
+        "repo": "ywj3493/claude-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "explainable@claude-skills": true
   }
 }


### PR DESCRIPTION
## 개요

`ywj3493/claude-skills` 마켓플레이스를 프로젝트 스코프로 등록하고, 그 하위의 `explainable` 플러그인(v0.2.0)을 설치했습니다.

## 변경 내용

`.claude/settings.json`에 두 개의 키가 추가되었습니다.

- `extraKnownMarketplaces.claude-skills` — GitHub 소스 `ywj3493/claude-skills` 마켓플레이스 선언
- `enabledPlugins["explainable@claude-skills"]` — 플러그인 활성화

프로젝트 스코프이므로 이 저장소에서 작업하는 모든 팀원/에이전트 세션에 자동으로 적용됩니다.

## 플러그인 구성 (explainable 0.2.0)

- **Skills (7)**: `init-planning`, `init-design-backend`, `init-design-frontend`, `reverse-planning`, `reverse-design-backend`, `reverse-design-frontend`, `translate-docs`
- **Agents (4)**: `infra-explorer`, `operation-tracer`, `render-flow-tracer`, `citation-verifier`
- Hooks / MCP / LSP 서버 없음
- 상시 토큰 비용 약 2.8k (세션당)

## 확인

- `claude plugin list` → `explainable@claude-skills` / scope: project / enabled 확인
- `settings.json` JSON 유효성 확인, 기존 permissions·hooks 설정은 순서까지 그대로 유지 (추가분만 diff에 반영)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nz8CrgrE9jUbbJ5UMG9kSy)_